### PR TITLE
Further porting fixes

### DIFF
--- a/common/src/main/java/net/venturecraft/gliders/common/GliderEvents.java
+++ b/common/src/main/java/net/venturecraft/gliders/common/GliderEvents.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class GliderEvents implements PlayerEvents.Tracking, EntityEvents.LightningStrike, LivingEntityEvents.ItemUse, PlayerEvents.AnvilUpdate {
+public class GliderEvents implements PlayerEvents.Tracking, EntityEvents.LightningStrike, LivingEntityEvents.ItemUse {
 
     public static void initEvents() {
         GliderEvents instance = new GliderEvents();
@@ -35,7 +35,6 @@ public class GliderEvents implements PlayerEvents.Tracking, EntityEvents.Lightni
         LivingEntityEvents.ITEM_USE_START.register(instance);
         LivingEntityEvents.ITEM_USE_TICK.register(instance);
         LivingEntityEvents.ITEM_USE_STOP.register(instance);
-        PlayerEvents.ANVIL_UPDATE.register(instance);
         PlayerEvents.START_TRACKING.register(instance);
     }
 
@@ -69,40 +68,6 @@ public class GliderEvents implements PlayerEvents.Tracking, EntityEvents.Lightni
     @Override
     public EventResult livingEntityItemUse(LivingEntity entity, @NotNull ItemStack stack, AtomicInteger duration) {
         return GliderUtil.isGlidingWithActiveGlider(entity) ? EventResult.cancel() : EventResult.pass();
-    }
-
-
-    @Override
-    public EventResult anvilUpdate(Player player, ItemStack left, ItemStack right, @Nullable String name, AtomicLong cost, AtomicInteger materialCost, AtomicReference<ItemStack> output) {
-        if(left.getItem() instanceof GliderItem gliderItem) {
-
-            // Glider Repair
-            if (gliderItem.isValidRepairItem(left, right)) {
-                ItemStack data = left.copy();
-                GliderItem.setBroken(data, false);
-                data.setDamageValue(0);
-                cost.set(5);
-                output.set(data);
-            }
-
-            if(right.getItem() == ItemRegistry.COPPER_UPGRADE.get()){
-                ItemStack data = left.copy();
-                data = GliderItem.setCopper(data, true);
-                cost.set(10);
-                output.set(data);
-            }
-
-            if(right.getItem() == ItemRegistry.NETHER_UPGRADE.get()){
-                ItemStack data = left.copy();
-                data = GliderItem.setNether(data, true);
-                cost.set(10);
-                output.set(data);
-            }
-        }
-
-
-
-        return EventResult.pass();
     }
 
     @Override

--- a/common/src/main/java/net/venturecraft/gliders/common/item/GliderItem.java
+++ b/common/src/main/java/net/venturecraft/gliders/common/item/GliderItem.java
@@ -74,7 +74,7 @@ public class GliderItem extends Item implements Equipable {
     }
 
     public static void setBroken(ItemStack itemStack, boolean broken) {
-        itemStack.set(ItemComponentRegistry.STRUCK.get(), broken);
+        itemStack.set(ItemComponentRegistry.BROKEN.get(), broken);
     }
 
     public static boolean isBroken(ItemStack itemStack) {

--- a/fabric/src/main/java/net/venturecraft/gliders/mixin/fabric/AnvilMenuMixin.java
+++ b/fabric/src/main/java/net/venturecraft/gliders/mixin/fabric/AnvilMenuMixin.java
@@ -1,0 +1,69 @@
+package net.venturecraft.gliders.mixin.fabric;
+
+
+
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.*;
+import net.minecraft.world.item.ItemStack;
+import net.venturecraft.gliders.common.item.GliderItem;
+import net.venturecraft.gliders.common.item.ItemRegistry;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AnvilMenu.class)
+public abstract class AnvilMenuMixin extends ItemCombinerMenu {
+    @Shadow
+    @Final
+    private DataSlot cost;
+
+    protected AnvilMenuMixin(@Nullable MenuType<?> type, int containerId, Inventory playerInventory, ContainerLevelAccess access) {
+        super(type, containerId, playerInventory, access);
+    }
+
+    /**
+     * Credits to <a href="https://github.com/hiisuuii/infinicore/blob/master/src%2Fmain%2Fjava%2Fhisui%2Finfinicore%2Fmixin%2FInfinicoreMixin.java#L27">Infinicore's Implementation of Anvil Recipes</a>
+     * for the correct mixin target.
+     */
+    @Inject(method = "createResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;isDamageableItem()Z", ordinal = 0), cancellable = true)
+    private void upgradeGlider(CallbackInfo ci) {
+
+        ItemStack left = inputSlots.getItem(0);
+        ItemStack right = inputSlots.getItem(1);
+
+        if(left.getItem() instanceof GliderItem gliderItem) {
+
+            // Glider Repair
+            if (gliderItem.isValidRepairItem(left, right)) {
+                ItemStack data = left.copy();
+                GliderItem.setBroken(data, false);
+                data.setDamageValue(0);
+                cost.set(5);
+                resultSlots.setItem(0, data);
+                ci.cancel();
+                return;
+            }
+
+            if (right.getItem() == ItemRegistry.COPPER_UPGRADE.get()) {
+                ItemStack data = left.copy();
+                GliderItem.setCopper(data, true);
+                cost.set(10);
+                resultSlots.setItem(0, data);
+                ci.cancel();
+                return;
+            }
+
+            if(right.getItem() == ItemRegistry.NETHER_UPGRADE.get()) {
+                ItemStack data = left.copy();
+                GliderItem.setNether(data, true);
+                cost.set(10);
+                resultSlots.setItem(0, data);
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -29,6 +29,7 @@
   "depends": {
     "fabric-api": "*",
     "minecraft": ">=1.21",
-    "palladiumcore": ">=1.19.2-1.2.0.0"
+    "palladiumcore": ">=1.19.2-1.2.0.0",
+    "commonnetworking": "*"
   }
 }

--- a/fabric/src/main/resources/vc_gliders.mixins.json
+++ b/fabric/src/main/resources/vc_gliders.mixins.json
@@ -6,6 +6,7 @@
     "LevelRendererMixin"
   ],
   "mixins": [
+    "AnvilMenuMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ mod_license=GPL-3.0-or-later
 maven_group=net.venturecraft.gliders
 
 # Common Dependencies
-palladiumcore_version=2.3.3+1.21.1
+palladiumcore_version=2.3.3.1+1.21.1
 
 # Fabric Dependencies
 fabric_loader_version=0.16.14

--- a/neoforge/src/generated/resources/data/curios/tags/item/back.json
+++ b/neoforge/src/generated/resources/data/curios/tags/item/back.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "vc_gliders:paraglider_wood",
+    "vc_gliders:paraglider_iron",
+    "vc_gliders:paraglider_gold",
+    "vc_gliders:paraglider_diamond",
+    "vc_gliders:paraglider_netherite"
+  ]
+}

--- a/neoforge/src/generated/resources/data/curios/tags/item/cape.json
+++ b/neoforge/src/generated/resources/data/curios/tags/item/cape.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "vc_gliders:paraglider_wood",
+    "vc_gliders:paraglider_iron",
+    "vc_gliders:paraglider_gold",
+    "vc_gliders:paraglider_diamond",
+    "vc_gliders:paraglider_netherite"
+  ]
+}

--- a/neoforge/src/generated/resources/data/vc_gliders/curios/entities/entities.json
+++ b/neoforge/src/generated/resources/data/vc_gliders/curios/entities/entities.json
@@ -1,0 +1,9 @@
+{
+  "entities": [
+    "minecraft:player"
+  ],
+  "slots": [
+    "back",
+    "cape"
+  ]
+}

--- a/neoforge/src/main/java/net/venturecraft/gliders/compat/trinket/CuriosUtil.java
+++ b/neoforge/src/main/java/net/venturecraft/gliders/compat/trinket/CuriosUtil.java
@@ -1,27 +1,17 @@
 package net.venturecraft.gliders.compat.trinket;
 
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.fml.InterModComms;
-import net.neoforged.fml.event.lifecycle.InterModEnqueueEvent;
-import net.venturecraft.gliders.VCGliders;
 import net.venturecraft.gliders.common.compat.trinket.CuriosTrinketsSlotInv;
 import net.venturecraft.gliders.common.compat.trinket.CuriosTrinketsUtil;
 import top.theillusivec4.curios.api.CuriosApi;
-import top.theillusivec4.curios.api.SlotTypeMessage;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 
 public class CuriosUtil extends CuriosTrinketsUtil {
 
     public static void init(IEventBus eventBus) {
         CuriosTrinketsUtil.setInstance(new CuriosUtil());
-        eventBus.addListener(CuriosUtil::interModQueue);
-    }
-
-    public static void interModQueue(InterModEnqueueEvent e) {
-        InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> new SlotTypeMessage.Builder("glider").size(1).icon(VCGliders.id("item/glider_slot")).build());
     }
 
     @Override
@@ -32,7 +22,7 @@ public class CuriosUtil extends CuriosTrinketsUtil {
     @Override
     public CuriosTrinketsSlotInv getSlot(LivingEntity entity, String slot) {
         final CuriosTrinketsSlotInv[] slotHandler = {CuriosTrinketsSlotInv.EMPTY};
-        CuriosApi.getCuriosHelper().getCuriosHandler(entity).ifPresent(curios -> {
+        CuriosApi.getCuriosInventory(entity).ifPresent(curios -> {
             curios.getStacksHandler(slot).ifPresent(stacks -> {
                 slotHandler[0] = new SlotInv(stacks.getStacks());
             });

--- a/neoforge/src/main/java/net/venturecraft/gliders/neoforge/GliderEventsNeoForge.java
+++ b/neoforge/src/main/java/net/venturecraft/gliders/neoforge/GliderEventsNeoForge.java
@@ -1,0 +1,42 @@
+package net.venturecraft.gliders.neoforge;
+
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.AnvilUpdateEvent;
+import net.venturecraft.gliders.VCGliders;
+import net.venturecraft.gliders.common.item.GliderItem;
+import net.venturecraft.gliders.common.item.ItemRegistry;
+
+@EventBusSubscriber(modid = VCGliders.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
+public class GliderEventsNeoForge {
+    @SubscribeEvent
+    public static void onAnvilUpdate(AnvilUpdateEvent event) {
+        ItemStack left = event.getLeft();
+        ItemStack right = event.getRight();
+
+        if (left.getItem() instanceof GliderItem gliderItem) {
+            if (gliderItem.isValidRepairItem(left, right)) {
+                ItemStack result = left.copy();
+                GliderItem.setBroken(result, false);
+                result.setDamageValue(0);
+                event.setCost(5);
+                event.setOutput(result);
+            }
+
+            if (right.getItem() == ItemRegistry.COPPER_UPGRADE.get()) {
+                event.setCost(10);
+                var data = left.copy();
+                GliderItem.setCopper(data, true);
+                event.setOutput(data);
+            }
+
+            if (right.getItem() == ItemRegistry.NETHER_UPGRADE.get()) {
+                event.setCost(10);
+                var data = left.copy();
+                GliderItem.setNether(data, true);
+                event.setOutput(data);
+            }
+        }
+    }
+}

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -37,7 +37,7 @@ side = "BOTH"
 [[dependencies.vc_gliders]]
 modId = "commonnetworking"
 mandatory = true
-versionRange = "[1.0.18-1.21.1,)"
+versionRange = "[1.0.16-1.21,)"
 ordering = "AFTER"
 side = "BOTH"
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -34,5 +34,12 @@ versionRange = "[1.19.2-1.2.0.0,)"
 ordering = "AFTER"
 side = "BOTH"
 
+[[dependencies.vc_gliders]]
+modId = "commonnetworking"
+mandatory = true
+versionRange = "[1.0.18-1.21.1,)"
+ordering = "AFTER"
+side = "BOTH"
+
 [[mixins]]
 config = "vc_gliders-common.mixins.json"


### PR DESCRIPTION
- Fixed multiplayer crashing - disabled part of Palladium Core, we'll be dropping it eventually anyway and there's no official release of it.
- Fixed anvil recipes not working - Palladium Core's event was broken, so I've moved to an approach similar to 1.20 standalone.
- Fixed lightning strikes not breaking Gliders.
- Fixed Curios, now properly relies on its data-driven system.

Tested this out with a friend, should be good to go!